### PR TITLE
Bump to go 1.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+haddock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.3-alpine3.12 as build
+FROM golang:1.19.2-alpine3.12 as build
 LABEL maintainer="Galen Guyer <galen@galenguyer.com>"
 WORKDIR /app
 COPY main.go .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2-alpine3.12 as build
+FROM golang:1.19.2-alpine3.16 as build
 LABEL maintainer="Galen Guyer <galen@galenguyer.com>"
 WORKDIR /app
 COPY main.go .

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/computersciencehouse/haddock
+
+go 1.19


### PR DESCRIPTION
This PR bumps haddock to use go1.19 by bumping the builder image in the dockerfile and by including a go1.19 versioned go.mod file in the project root.


Also adds `haddock` binary to the `.gitignore` file.